### PR TITLE
Fixed a bug that keeps old split files loaded

### DIFF
--- a/src/FileCutter/Process.cs
+++ b/src/FileCutter/Process.cs
@@ -74,8 +74,9 @@ namespace FileCutter
                             flag = true;
                             outputFile.Write(buffer, 0, bytesRead);
                         }
+                        outputFile.Close();
                     }
-
+                    
                     if (!flag)
                         File.Delete(pathFileName);
                 }
@@ -104,7 +105,7 @@ namespace FileCutter
                             outputFile.Write(buffer, 0, bytesRead);
                             remaining -= bytesRead;
                         }
-
+                        outputFile.Close();
                         position++;
                     }
                 }


### PR DESCRIPTION
This drastically helps with memory when splitting large files, as the old files that were split never get unloaded until the end of the splitting process.